### PR TITLE
Changed Gmail's @font-face support to a «no»

### DIFF
--- a/docs/_data/features.yaml
+++ b/docs/_data/features.yaml
@@ -375,7 +375,7 @@
       href: "https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face"
       clients:
         - client: "1"
-          compatible: "yes"
+          compatible: "no"
         - client: "2"
           compatible: "no"
         - client: "3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed Gmail's `@font-face` support to a «no». 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
caniuse.email shows incorrect data about Gmail's `@font-face` support.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Isolated test cases as well as HTML emails under development sent to myself via a PHP script. Tried `@font-face` declarations in style tags and inside link tags. Both don't work and get stripped.
<!--- Include details of your testing environment, tests ran to see how -->
Tested on: Windows 10. Gmail in fresh Firefox, Chrome. Android 9: fresh and official Gmail app.
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
